### PR TITLE
Richer results

### DIFF
--- a/.github/workflows/build-test-pullrequest.yml
+++ b/.github/workflows/build-test-pullrequest.yml
@@ -17,14 +17,6 @@ jobs:
       - name: Build Projects
         id: buildproj
         run: npm run build
-      - name: Run Unit Tests
+      - name: Run Unit Tests with Coverage
         id: unittest
-        run: npm run test
-      - name: Functional Test
-        # only run functional tests on internal PRs
-        if: github.repository == 'bicarbon8/automated-functional-testing'
-        id: functionaltest
-        run: npm run test:examples
-        env:
-          browserstack_user: ${{ secrets.BROWSERSTACK_USER }}
-          browserstack_key: ${{ secrets.BROWSERSTACK_KEY }}
+        run: npm run coverage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const unsuccessful = store.add({
     created: Date.now(),
     lastUpdated: Date.now(),
     active: true
-}); // record not added to to unique index violation
+}); // record not added due to unique index violation
 ```
 Reading records from the `DynamicDataStore` is done using the `select` or `selectFirst` function when you want records matching certain constraints:
 ```typescript

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Reading records from the `DynamicDataStore` is done using the `select` function 
 const allActiveRecords = store.select({
     active: true
 }); // an array of 0 to many records
-const firstActiveRecordCreatedBeforeTimestamp = store.select({
+const record = store.select({
     active: true,
     created: lessThan(timestampMilliseconds)
-}).first(); // a single record or undefined if no matching records
+}).first; // a single record or undefined if no matching records
 ```
 Updating records is done using the `update` function which can be used to update a single record if your `updates` object contains values for the properties used as indicies:
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamic-data-store",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamic-data-store",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-data-store",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "a no-sql data storage solution supporting dynamic primary key designation and hashmap storage as well as partial object based query filters",
   "main": "dist/src/index.js",
   "scripts": {

--- a/src/dynamic-data-store-records.ts
+++ b/src/dynamic-data-store-records.ts
@@ -1,3 +1,5 @@
+import { JsonHelper } from "./json-helper";
+
 export type Order = 'asc' | 'desc';
 
 export class DynamicDataStoreRecords<T extends {}> {
@@ -14,12 +16,12 @@ export class DynamicDataStoreRecords<T extends {}> {
             let bStr: string = '';
             if (keys?.length > 0) {
                 for (let key of keys) {
-                    aStr += (a?.[key] != null) ? JSON.stringify(a[key]) : this._highValueCharacters;
-                    bStr += (b?.[key] != null) ? JSON.stringify(b[key]) : this._highValueCharacters;
+                    aStr += (a?.[key] != null) ? JSON.stringify(a[key], JsonHelper.replacer) : this._highValueCharacters;
+                    bStr += (b?.[key] != null) ? JSON.stringify(b[key], JsonHelper.replacer) : this._highValueCharacters;
                 }
             } else {
-                aStr = (a != null) ? JSON.stringify(a) : this._highValueCharacters;
-                bStr = (b != null) ? JSON.stringify(b) : this._highValueCharacters;
+                aStr = (a != null) ? JSON.stringify(a, JsonHelper.replacer) : this._highValueCharacters;
+                bStr = (b != null) ? JSON.stringify(b, JsonHelper.replacer) : this._highValueCharacters;
             }
             if (aStr < bStr) {
                 if (order === 'asc') {
@@ -40,15 +42,23 @@ export class DynamicDataStoreRecords<T extends {}> {
         return this;
     }
 
-    count(val: number): T | Array<T> {
-        if (val === 0) {
-            return undefined;
+    count(val: number | string): Array<T> {
+        if (typeof val === 'number') {
+            if (val >= 0) {
+                return this.data.slice(0, val);
+            }
         }
-        if (val === 1) {
-            return (this.data.length > 0) ? this.data[0] : undefined;
+        if (val === '*') {
+            return this.data;
         }
-        if (val > 1 || val < 0) {
-            return this.data.slice(0, val);
-        }
+        return undefined;
+    }
+
+    first(): T {
+        return (this.data.length > 0) ? this.data[0] : undefined;
+    }
+
+    last(): T {
+        return (this.data.length > 0) ? this.data[this.data.length - 1] : undefined;
     }
 }

--- a/src/dynamic-data-store-records.ts
+++ b/src/dynamic-data-store-records.ts
@@ -1,0 +1,54 @@
+export type Order = 'asc' | 'desc';
+
+export class DynamicDataStoreRecords<T extends {}> {
+    public readonly data: Array<T>;
+    private readonly _highValueCharacters = '\u9999\u9999\u9999\u9999\u9999\u9999';
+
+    constructor(...inputs: Array<T>) {
+        this.data = inputs ?? new Array<T>();
+    }
+
+    orderBy(order: Order = 'asc', ...keys: Array<keyof T>): this {
+        this.data.sort((a: T, b: T) => {
+            let aStr: string = '';
+            let bStr: string = '';
+            if (keys?.length > 0) {
+                for (let key of keys) {
+                    aStr += (a?.[key] != null) ? JSON.stringify(a[key]) : this._highValueCharacters;
+                    bStr += (b?.[key] != null) ? JSON.stringify(b[key]) : this._highValueCharacters;
+                }
+            } else {
+                aStr = (a != null) ? JSON.stringify(a) : this._highValueCharacters;
+                bStr = (b != null) ? JSON.stringify(b) : this._highValueCharacters;
+            }
+            if (aStr < bStr) {
+                if (order === 'asc') {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            } else if (aStr > bStr) {
+                if (order === 'asc') {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            } else {
+                return 0;
+            }
+        });
+        return this;
+    }
+
+    count(val: number): T | Array<T> {
+        if (val === 0) {
+            return undefined;
+        }
+        if (val === 1) {
+            return (this.data.length > 0) ? this.data[0] : undefined;
+        }
+        if (val > 1 || val < 0) {
+            return this.data.slice(0, val);
+        }
+    }
+}

--- a/src/dynamic-data-store-records.ts
+++ b/src/dynamic-data-store-records.ts
@@ -11,7 +11,26 @@ export class DynamicDataStoreRecords<T extends {}> extends Array<T> {
         super(...inputs);
         this._indicies = indicies;
     }
+
+    get first(): T {
+        return (this.length > 0) ? this[0] : undefined;
+    }
+
+    get last(): T {
+        return (this.length > 0) ? this[this.length - 1] : undefined;
+    }
     
+    /**
+     * orders the records by either the entire record or by specific property keys where
+     * the order that the property keys are specified is important to the orderting of
+     * the records. NOTE: any fields set to `null` or `undefined` that are used for 
+     * ordering the records will be assigned a high value resulting in them being ordered
+     * at the end of the records array if using an order of `asc`
+     * @param order a value of either 'asc' for ascending or 'desc' for descending
+     * @param keys the property keys to use to order the records. records will be ordered by
+     * each property key in the order they're passed
+     * @returns a reference to this {DynamicDataStoreRecords}
+     */
     orderBy(order: Order = 'asc', ...keys: Array<keyof T>): this {
         this.sort((a: T, b: T) => {
             let aStr: string = '';
@@ -44,26 +63,15 @@ export class DynamicDataStoreRecords<T extends {}> extends Array<T> {
         return this;
     }
 
-    count(val: number | string): Array<T> {
-        if (typeof val === 'number') {
-            if (val >= 0) {
-                return this.slice(0, val);
-            }
-        }
-        if (val === '*') {
-            return this;
-        }
-        return undefined;
-    }
-
-    first(): T {
-        return (this.length > 0) ? this[0] : undefined;
-    }
-
-    last(): T {
-        return (this.length > 0) ? this[this.length - 1] : undefined;
-    }
-
+    /**
+     * finds all records in the `DynamicDataStore` whose values match those
+     * passed in the supplied record. NOTE: any properties not specified will
+     * be ignored
+     * @param query a record object where any keys of type `T` are set to either 
+     * the exact value expected or a `ValueMatcher` used to identify values
+     * conforming to certain criteria
+     * @returns an array of all matching records
+     */
     select(query?: Partial<Record<keyof T, QueryValue>>): DynamicDataStoreRecords<T> {
         return new DynamicDataStore({
             indicies: this._indicies,

--- a/src/dynamic-data-store-records.ts
+++ b/src/dynamic-data-store-records.ts
@@ -1,17 +1,19 @@
+import { DynamicDataStore, QueryValue } from "./dynamic-data-store";
 import { JsonHelper } from "./json-helper";
 
 export type Order = 'asc' | 'desc';
 
-export class DynamicDataStoreRecords<T extends {}> {
-    public readonly data: Array<T>;
+export class DynamicDataStoreRecords<T extends {}> extends Array<T> {
     private readonly _highValueCharacters = '\u9999\u9999\u9999\u9999\u9999\u9999';
+    private readonly _indicies: Array<keyof T>;
 
-    constructor(...inputs: Array<T>) {
-        this.data = inputs ?? new Array<T>();
+    constructor(indicies: Array<keyof T>, ...inputs: Array<T>) {
+        super(...inputs);
+        this._indicies = indicies;
     }
-
+    
     orderBy(order: Order = 'asc', ...keys: Array<keyof T>): this {
-        this.data.sort((a: T, b: T) => {
+        this.sort((a: T, b: T) => {
             let aStr: string = '';
             let bStr: string = '';
             if (keys?.length > 0) {
@@ -45,20 +47,27 @@ export class DynamicDataStoreRecords<T extends {}> {
     count(val: number | string): Array<T> {
         if (typeof val === 'number') {
             if (val >= 0) {
-                return this.data.slice(0, val);
+                return this.slice(0, val);
             }
         }
         if (val === '*') {
-            return this.data;
+            return this;
         }
         return undefined;
     }
 
     first(): T {
-        return (this.data.length > 0) ? this.data[0] : undefined;
+        return (this.length > 0) ? this[0] : undefined;
     }
 
     last(): T {
-        return (this.data.length > 0) ? this.data[this.data.length - 1] : undefined;
+        return (this.length > 0) ? this[this.length - 1] : undefined;
+    }
+
+    select(query?: Partial<Record<keyof T, QueryValue>>): DynamicDataStoreRecords<T> {
+        return new DynamicDataStore({
+            indicies: this._indicies,
+            records: this
+        }).select(query);
     }
 }

--- a/src/dynamic-data-store.ts
+++ b/src/dynamic-data-store.ts
@@ -176,6 +176,7 @@ export class DynamicDataStore<T extends {}> {
                     return false;
                 }
             }
+            return true;
         }
         return false;
     }

--- a/src/dynamic-data-store.ts
+++ b/src/dynamic-data-store.ts
@@ -109,6 +109,7 @@ export class DynamicDataStore<T extends {}> {
     select(query?: Query<T>): DynamicDataStoreRecords<T> {
         const records = this._performQuery(query);
         return new DynamicDataStoreRecords(
+            this.indicies,
             ...JSON.parse(
                 JSON.stringify(records, JsonHelper.replacer), 
                 JsonHelper.reviver

--- a/src/dynamic-data-store.ts
+++ b/src/dynamic-data-store.ts
@@ -233,25 +233,35 @@ export class DynamicDataStore<T extends {}> {
                 }
             } else {
                 const sArr = Array.from(this._store.values());
-                const queryKeys = Object.keys(query);
-                results.splice(0, 0, ...sArr.filter(r => {
-                    for (let prop of queryKeys) {
-                        if (query[prop] instanceof ValueMatcher) {
-                            if (!query[prop].isMatch(r[prop])) {
-                                return false;
-                            }
-                        } else {
-                            if (query[prop] !== r[prop]) {
-                                return false;
-                            }
-                        }
-                    }
-                    return true;
-                }));
+                results.splice(0, 0, ...sArr.filter(r => this._recordMatches(query, r)));
             }
         } else {
             results.splice(0, 0, ...this._store.values());
         }
         return results;
+    }
+
+    private _recordMatches(query: {}, record: {}): boolean {
+        const queryKeys = Object.keys(query);
+        for (let prop of queryKeys) {
+            if (query[prop] instanceof ValueMatcher) {
+                if (!query[prop].isMatch(record[prop])) {
+                    return false;
+                }
+            } else {
+                if (typeof query[prop] === 'object' && query[prop] !== null) {
+                    if (record[prop] == null) {
+                        return false;
+                    }
+                    const result = this._recordMatches(query[prop], record[prop]);
+                    if (result === false) {
+                        return false;
+                    }
+                } else if (query[prop] !== record[prop]) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/dynamic-data-store.ts
+++ b/src/dynamic-data-store.ts
@@ -135,38 +135,6 @@ export class DynamicDataStore<T extends {}> {
     }
 
     /**
-     * finds the first object containing matching values for the supplied fields
-     * in `query`
-     * @param query an optional object containing one or more fields in type `T`
-     * @returns the first non-null (and non-undefined) object matching values
-     * for all fields supplied in `query`
-     */
-    selectFirst(query?: Query<T>): T {
-        const results = this.select(query);
-        return results.find(r => r != null);
-    }
-
-    /**
-     * gets the object contained in the `DynamicDataStore` whose index property
-     * values match those supplied in the passed in object
-     * @param containsIndexProps an object containing all properties used
-     * as index properties
-     * @returns a single object matching the supplied index properties or
-     * `undefined` if none exist or the passed in object does not contain all the
-     * expected index properties
-     */
-    get(containsIndexProps: Partial<T>): T {
-        const key = this.getIndex(containsIndexProps);
-        if (key) {
-            const record = this._store.get(key);
-            if (record) {
-                return JSON.parse(JSON.stringify(record));
-            }
-        }
-        return undefined;
-    }
-
-    /**
      * returns the number of records matching the specified selection
      * criteria passed in `query`
      * @param query an optional object containing one or more properties in type `T`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+export * from "./dynamic-data-store-records";
 export * from "./dynamic-data-store";
+export * from "./json-helper";
 export * from "./value-matcher";

--- a/src/json-helper.ts
+++ b/src/json-helper.ts
@@ -1,0 +1,37 @@
+export type MapJson = {
+    dataType: 'Map';
+    value: Array<any>;
+};
+export type SetJson = {
+    dataType: 'Set';
+    value: Array<any>;
+};
+
+export module JsonHelper {
+    export const replacer = (key: unknown, val: unknown): unknown => {
+        if (val instanceof Map) {
+            return {
+                dataType: 'Map',
+                value: Array.from(val.entries())
+            } as MapJson;
+        }
+        if (val instanceof Set) {
+            return {
+                dataType: 'Set',
+                value: Array.from(val.entries())
+            } as SetJson;
+        }
+        return val;
+    }
+    export const reviver = (key: unknown, val: unknown): any => {
+        if (typeof val === 'object' && val !== null) {
+            if ((val as MapJson)?.dataType === 'Map') {
+                return new Map((val as MapJson).value);
+            }
+            if ((val as SetJson)?.dataType === 'Set') {
+                return new Set((val as SetJson).value);
+            }
+        }
+        return val;
+    }
+}

--- a/src/value-matcher.ts
+++ b/src/value-matcher.ts
@@ -332,3 +332,31 @@ class EndingWith extends ValueMatcher {
  * @returns `true` if the `actual` value ends with `end`; otherwise `false`
  */
 export const endingWith = (end?: string | number | boolean) => new EndingWith(end);
+
+class HavingValue implements ValueMatcher {
+    isMatch(actual?: unknown): boolean {
+        return actual != null;
+    }
+}
+/**
+ * verifies that the `actual` value is set to something other than `null` or
+ * `undefined`
+ * @returns `true` if the `actual` value is not `null` or `undefined`
+ */
+export const havingValue = () => new HavingValue();
+
+class Not implements ValueMatcher {
+    public readonly notExpected: ValueMatcher;
+    constructor(notExpected: ValueMatcher) {
+        this.notExpected = notExpected;
+    }
+    isMatch(actual?: unknown): boolean {
+        return !this.notExpected.isMatch(actual);
+    }
+}
+/**
+ * inverts the result of any {ValueMatcher} passed to it
+ * @param notExpected a {ValueMatcher} to be negated
+ * @returns `true` if the passed in `notExpected` returns `false`; otherwise `false`
+ */
+export const not = (notExpected: ValueMatcher) => new Not(notExpected);

--- a/test/dynamic-data-store-records.spec.ts
+++ b/test/dynamic-data-store-records.spec.ts
@@ -1,0 +1,100 @@
+import { DynamicDataStoreRecords, matching } from "../src"
+
+describe('DynamicDataStoreRecords', () => {
+    it('can order records by single key acending', () => {
+        const records = new DynamicDataStoreRecords([], 
+            {name: 'bcd234'},
+            {name: 'abc234'},
+            {name: 'bcd123'},
+            {name: 'abc123'}
+        );
+        records.orderBy('asc', 'name');
+
+        expect(records.first.name).toEqual('abc123');
+        expect(records.last.name).toEqual('bcd234');
+        expect(records[1].name).toEqual('abc234');
+        expect(records[2].name).toEqual('bcd123');
+    })
+
+    it('can order records by single key descending', () => {
+        const records = new DynamicDataStoreRecords([], 
+            {name: 'bcd234'},
+            {name: 'abc234'},
+            {name: 'bcd123'},
+            {name: 'abc123'}
+        );
+        records.orderBy('desc', 'name');
+
+        expect(records.first.name).toEqual('bcd234');
+        expect(records.last.name).toEqual('abc123');
+        expect(records[1].name).toEqual('bcd123');
+        expect(records[2].name).toEqual('abc234');
+    })
+
+    it('can order records by multiple keys ascending', () => {
+        const records = new DynamicDataStoreRecords([],
+            {name: 'def', num: 123},
+            {name: 'def', num: 234},
+            {name: 'bcd', num: 234},
+            {name: 'cde', num: 123},
+            {name: 'bcd', num: 123},
+            {name: 'abc', num: 123}
+        );
+        records.orderBy('asc', 'name', 'num');
+
+        expect(records.first.name).toEqual('abc');
+        expect(records.first.num).toBe(123);
+        expect(records.last.name).toEqual('def');
+        expect(records.last.num).toBe(234);
+    })
+
+    it('orders based on passed in key order', () => {
+        const records = new DynamicDataStoreRecords([],
+            {name: 'def', num: 123},
+            {name: 'def', num: 234},
+            {name: 'bcd', num: 234},
+            {name: 'cde', num: 123},
+            {name: 'bcd', num: 123},
+            {name: 'abc', num: 345}
+        );
+        records.orderBy('asc', 'num', 'name');
+
+        expect(records.first.name).toEqual('bcd');
+        expect(records.first.num).toBe(123);
+        expect(records.last.name).toEqual('abc');
+        expect(records.last.num).toBe(345);
+    })
+
+    it('can order objects ascending when no keys specified', () => {
+        const records = new DynamicDataStoreRecords([],
+            {name: 'def', num: 123},
+            {name: 'def', num: 234},
+            {name: 'bcd', num: 234},
+            {name: 'bcd', num: 234},
+            {name: 'cde', num: 123},
+            {name: 'bcd', num: 123},
+            {name: 'abc', num: 123}
+        );
+        records.orderBy('asc');
+
+        expect(records.first.name).toEqual('abc');
+        expect(records.first.num).toBe(123);
+        expect(records.last.name).toEqual('def');
+        expect(records.last.num).toBe(234);
+    })
+
+    it('can can be queried to create subset of results', () => {
+        const records = new DynamicDataStoreRecords([],
+            {name: 'def', num: 123},
+            {name: 'def', num: 234},
+            {name: 'bcd', num: 234},
+            {name: 'cde', num: 123},
+            {name: 'bcd', num: 123},
+            {name: 'abc', num: 123}
+        ).select({name: matching(/(bcd|cde)/)});
+
+        expect(records.length).toBe(3);
+        expect(records.select({name: 'cde'}).length).toBe(1);
+        expect(records.select({name: 'bcd'}).length).toBe(2);
+    })
+})

--- a/test/dynamic-data-store.spec.ts
+++ b/test/dynamic-data-store.spec.ts
@@ -10,60 +10,60 @@ type TestObj = {
 
 describe('DynamicDataStore', () => {
     it('can add records via contructor options', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             records: [
                 { strKey: 'foo', boolKey: true },
                 { strKey: 'foo', boolKey: false }
             ]
         });
 
-        expect(dt.size()).withContext('number of records in the table').toBe(2);
-        const actual = dt.select();
-        expect(actual.first().strKey).toEqual('foo');
-        expect(actual.first().boolKey).toBe(true);
+        expect(store.size()).withContext('number of records in the table').toBe(2);
+        const actual = store.select();
+        expect(actual.first.strKey).toEqual('foo');
+        expect(actual.first.boolKey).toBe(true);
         expect(actual[1].strKey).toEqual('foo');
         expect(actual[1].boolKey).toBe(false);
     })
 
     it('can add indexKeys via contructor options', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['boolKey']
         });
 
-        const actualKey = dt.getIndex({ strKey: 'foo', boolKey: true, numKey: 10 });
+        const actualKey = store.getIndex({ strKey: 'foo', boolKey: true, numKey: 10 });
         expect(actualKey).toEqual('true');
     })
 
     it('can add key delimiter via contructor options', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             delimiter: ':',
             indicies: ['strKey', 'numKey']
         });
 
-        const actualKey = dt.getIndex({ strKey: 'foo', boolKey: false, numKey: 111 });
+        const actualKey = store.getIndex({ strKey: 'foo', boolKey: false, numKey: 111 });
         expect(actualKey).toEqual('"foo":111');
     })
 
     it('does not update source table if returned record is modified', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['strKey'],
             records: [
                 { strKey: 'foo', boolKey: true, numKey: 222 }
             ]
         });
-        const record = dt.select().first();
+        const record = store.select().first;
         record.strKey = 'bar';
         record.boolKey = false;
         record.numKey = 333;
 
-        const actual = dt.select().first();
+        const actual = store.select().first;
         expect(actual.strKey).toEqual('foo');
         expect(actual.boolKey).toBe(true);
         expect(actual.numKey).toBe(222);
     })
 
     it('can update record using the update function', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['strKey', 'numKey'],
             records: [
                 {strKey: 'foo', boolKey: true, numKey: 1},
@@ -72,17 +72,17 @@ describe('DynamicDataStore', () => {
                 {strKey: 'foo', boolKey: true, numKey: 4}
             ]
         });
-        const count = dt.update({strKey: 'foo', boolKey: false, numKey: 2});
+        const count = store.update({strKey: 'foo', boolKey: false, numKey: 2});
 
         expect(count).withContext('only one record updated').toEqual(1);
-        const updated = dt.select({strKey: 'foo', numKey: 2}).first();
+        const updated = store.select({strKey: 'foo', numKey: 2}).first;
         expect(updated.boolKey).toBe(false);
-        const unchanged = dt.select({boolKey: true});
+        const unchanged = store.select({boolKey: true});
         expect(unchanged.length).toBe(3);
     })
 
     it('can update multiple records using the update function', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['strKey', 'numKey'],
             records: [
                 {strKey: 'foo', boolKey: true, numKey: 1},
@@ -91,18 +91,18 @@ describe('DynamicDataStore', () => {
                 {strKey: 'foo', boolKey: false, numKey: 4}
             ]
         });
-        const count = dt.update({boolKey: true}, {numKey: between(2, 3)});
+        const count = store.update({boolKey: true}, {numKey: between(2, 3)});
 
         expect(count).withContext('only two records updated').toBe(2);
-        const unchanged = dt.select({strKey: 'foo', numKey: 4}).first();
+        const unchanged = store.select({strKey: 'foo', numKey: 4}).first;
         expect(unchanged.boolKey).toBe(false);
-        const updated = dt.select({numKey: between(2, 3)});
+        const updated = store.select({numKey: between(2, 3)});
         expect(updated.length).toBe(2);
         expect(updated.every(c => c.boolKey === true)).toBe(true);
     })
 
     it('can remove records by query data', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             records: [
                 {strKey: 'foo', boolKey: true, numKey: 1},
                 {strKey: 'foo', boolKey: false, numKey: 2},
@@ -115,17 +115,17 @@ describe('DynamicDataStore', () => {
             ]
         });
 
-        const deleted = dt.delete({strKey: 'foo', boolKey: true});
+        const deleted = store.delete({strKey: 'foo', boolKey: true});
         expect(deleted.length).withContext('expected two records removed based on criteria').toBe(2);
         expect(deleted.filter(d => d.numKey === 1).length).toBe(1);
 
-        const remaining = dt.delete({strKey: matching(/(foo|bar)/)});
+        const remaining = store.delete({strKey: matching(/(foo|bar)/)});
         expect(remaining.length).toBe(6);
-        expect(dt.size()).toBe(0);
+        expect(store.size()).toBe(0);
     })
 
     it('can clear all records', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             records: [
                 {strKey: 'foo', boolKey: true, numKey: 1},
                 {strKey: 'foo', boolKey: false, numKey: 2},
@@ -138,28 +138,28 @@ describe('DynamicDataStore', () => {
             ]
         });
 
-        expect(dt.size()).toBe(8);
-        dt.clear();
-        expect(dt.size()).toBe(0);
+        expect(store.size()).toBe(8);
+        store.clear();
+        expect(store.size()).toBe(0);
     })
 
     it('does not allow the indexProperties array to be modified', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['strKey', 'numKey']
         });
 
-        const indexProps = [...dt.indicies];
+        const indexProps = [...store.indicies];
         
         expect(indexProps.length).toBe(2);
 
-        dt.indicies.splice(0, 1);
+        store.indicies.splice(0, 1);
 
-        expect(dt.indicies.length).toBe(2);
-        expect(dt.indicies).toEqual(indexProps);
+        expect(store.indicies.length).toBe(2);
+        expect(store.indicies).toEqual(indexProps);
     })
 
     it('allows queries to search nested objects', () => {
-        const dt = new DynamicDataStore<TestObj>({
+        const store = new DynamicDataStore<TestObj>({
             indicies: ['strKey', 'boolKey', 'numKey'],
             records: [
                 {strKey: 'foo', boolKey: true, numKey: 1, objKey: {strKey: 'bar'}},
@@ -173,9 +173,57 @@ describe('DynamicDataStore', () => {
             ]
         });
 
-        const results = dt.select({strKey: 'foo', objKey: {strKey: 'bar'}});
+        const results = store.select({strKey: 'foo', objKey: {strKey: 'bar'}});
         expect(results.length).toBe(2);
-        const valRes = dt.select({strKey: 'bar', objKey: {strKey: startingWith('ba')}});
+        const valRes = store.select({strKey: 'bar', objKey: {strKey: startingWith('ba')}});
         expect(valRes.length).toBe(4);
+    })
+
+    it('works when records contain a map', () => {
+        type MapObj = TestObj & {
+            mapObj: Map<string, any>;
+        };
+        const store = new DynamicDataStore<MapObj>({
+            indicies: ['mapObj'],
+            records: [
+                {strKey: 'abc', numKey: 1, mapObj: new Map<string, any>([['def', 456]])},
+                {strKey: 'bcd', numKey: 2, mapObj: new Map<string, any>([['cde', 345]])},
+                {strKey: 'cde', numKey: 3, mapObj: new Map<string, any>([['bcd', 234]])},
+                {strKey: 'def', numKey: 4, mapObj: new Map<string, any>([['abc', 123]])}
+            ]
+        });
+
+        expect(store.size()).toBe(4);
+
+        const records = store.select().orderBy('asc', 'mapObj');
+
+        expect(records.first.strKey).toEqual('def');
+        expect(records.first.numKey).toBe(4);
+        expect(records.last.strKey).toEqual('abc');
+        expect(records.last.numKey).toBe(1);
+    })
+
+    it('works when records contain a set', () => {
+        type SetObj = TestObj & {
+            setObj: Set<any>;
+        };
+        const store = new DynamicDataStore<SetObj>({
+            indicies: ['setObj'],
+            records: [
+                {strKey: 'abc', numKey: 1, setObj: new Set<any>([456])},
+                {strKey: 'bcd', numKey: 2, setObj: new Set<any>([345])},
+                {strKey: 'cde', numKey: 3, setObj: new Set<any>([234])},
+                {strKey: 'def', numKey: 4, setObj: new Set<any>([123])}
+            ]
+        });
+
+        expect(store.size()).toBe(4);
+
+        const records = store.select().orderBy('asc', 'setObj');
+
+        expect(records.first.strKey).toEqual('def');
+        expect(records.first.numKey).toBe(4);
+        expect(records.last.strKey).toEqual('abc');
+        expect(records.last.numKey).toBe(1);
     })
 })

--- a/test/dynamic-data-store.spec.ts
+++ b/test/dynamic-data-store.spec.ts
@@ -19,10 +19,10 @@ describe('DynamicDataStore', () => {
 
         expect(dt.size()).withContext('number of records in the table').toBe(2);
         const actual = dt.select();
-        expect(actual[0].strKey).toEqual('foo');
-        expect(actual[0].boolKey).toBe(true);
-        expect(actual[1].strKey).toEqual('foo');
-        expect(actual[1].boolKey).toBe(false);
+        expect(actual.first().strKey).toEqual('foo');
+        expect(actual.first().boolKey).toBe(true);
+        expect(actual.data[1].strKey).toEqual('foo');
+        expect(actual.data[1].boolKey).toBe(false);
     })
 
     it('can add indexKeys via contructor options', () => {

--- a/test/dynamic-data-store.spec.ts
+++ b/test/dynamic-data-store.spec.ts
@@ -17,7 +17,7 @@ describe('DynamicDataStore', () => {
             ]
         });
 
-        expect(dt.count()).withContext('number of records in the table').toBe(2);
+        expect(dt.size()).withContext('number of records in the table').toBe(2);
         const actual = dt.select();
         expect(actual[0].strKey).toEqual('foo');
         expect(actual[0].boolKey).toBe(true);
@@ -51,12 +51,12 @@ describe('DynamicDataStore', () => {
                 { strKey: 'foo', boolKey: true, numKey: 222 }
             ]
         });
-        const record = dt.selectFirst();
+        const record = dt.select().first();
         record.strKey = 'bar';
         record.boolKey = false;
         record.numKey = 333;
 
-        const actual = dt.selectFirst();
+        const actual = dt.select().first();
         expect(actual.strKey).toEqual('foo');
         expect(actual.boolKey).toBe(true);
         expect(actual.numKey).toBe(222);
@@ -75,10 +75,10 @@ describe('DynamicDataStore', () => {
         const count = dt.update({strKey: 'foo', boolKey: false, numKey: 2});
 
         expect(count).withContext('only one record updated').toEqual(1);
-        const updated = dt.selectFirst({strKey: 'foo', numKey: 2});
+        const updated = dt.select({strKey: 'foo', numKey: 2}).first();
         expect(updated.boolKey).toBe(false);
         const unchanged = dt.select({boolKey: true});
-        expect(unchanged.length).toBe(3);
+        expect(unchanged.data.length).toBe(3);
     })
 
     it('can update multiple records using the update function', () => {
@@ -94,11 +94,11 @@ describe('DynamicDataStore', () => {
         const count = dt.update({boolKey: true}, {numKey: between(2, 3)});
 
         expect(count).withContext('only two records updated').toBe(2);
-        const unchanged = dt.selectFirst({strKey: 'foo', numKey: 4});
+        const unchanged = dt.select({strKey: 'foo', numKey: 4}).first();
         expect(unchanged.boolKey).toBe(false);
         const updated = dt.select({numKey: between(2, 3)});
-        expect(updated.length).toBe(2);
-        expect(updated.every(c => c.boolKey === true)).toBe(true);
+        expect(updated.data.length).toBe(2);
+        expect(updated.data.every(c => c.boolKey === true)).toBe(true);
     })
 
     it('can remove records by query data', () => {
@@ -121,7 +121,7 @@ describe('DynamicDataStore', () => {
 
         const remaining = dt.delete({strKey: matching(/(foo|bar)/)});
         expect(remaining.length).toBe(6);
-        expect(dt.count()).toBe(0);
+        expect(dt.size()).toBe(0);
     })
 
     it('can clear all records', () => {
@@ -138,9 +138,9 @@ describe('DynamicDataStore', () => {
             ]
         });
 
-        expect(dt.count()).toBe(8);
+        expect(dt.size()).toBe(8);
         dt.clear();
-        expect(dt.count()).toBe(0);
+        expect(dt.size()).toBe(0);
     })
 
     it('does not allow the indexProperties array to be modified', () => {

--- a/test/dynamic-data-store.spec.ts
+++ b/test/dynamic-data-store.spec.ts
@@ -1,5 +1,5 @@
 import { DynamicDataStore } from "../src";
-import { between, containing, matching } from "../src/value-matcher";
+import { between, containing, matching, startingWith } from "../src/value-matcher";
 
 type TestObj = {
     strKey?: string;
@@ -156,5 +156,26 @@ describe('DynamicDataStore', () => {
 
         expect(dt.indicies.length).toBe(2);
         expect(dt.indicies).toEqual(indexProps);
+    })
+
+    it('allows queries to search nested objects', () => {
+        const dt = new DynamicDataStore<TestObj>({
+            indicies: ['strKey', 'boolKey', 'numKey'],
+            records: [
+                {strKey: 'foo', boolKey: true, numKey: 1, objKey: {strKey: 'bar'}},
+                {strKey: 'foo', boolKey: false, numKey: 2, objKey: {strKey: 'baz'}},
+                {strKey: 'foo', boolKey: false, numKey: 1, objKey: {strKey: 'bar'}},
+                {strKey: 'foo', boolKey: true, numKey: 2, objKey: {strKey: 'baz'}},
+                {strKey: 'bar', boolKey: true, numKey: 1, objKey: {strKey: 'bar'}},
+                {strKey: 'bar', boolKey: false, numKey: 2, objKey: {strKey: 'baz'}},
+                {strKey: 'bar', boolKey: false, numKey: 1, objKey: {strKey: 'bar'}},
+                {strKey: 'bar', boolKey: true, numKey: 2, objKey: {strKey: 'baz'}}
+            ]
+        });
+
+        const results = dt.select({strKey: 'foo', objKey: {strKey: 'bar'}});
+        expect(results.data.length).toBe(2);
+        const valRes = dt.select({strKey: 'bar', objKey: {strKey: startingWith('ba')}});
+        expect(valRes.data.length).toBe(4);
     })
 })

--- a/test/dynamic-data-store.spec.ts
+++ b/test/dynamic-data-store.spec.ts
@@ -21,8 +21,8 @@ describe('DynamicDataStore', () => {
         const actual = dt.select();
         expect(actual.first().strKey).toEqual('foo');
         expect(actual.first().boolKey).toBe(true);
-        expect(actual.data[1].strKey).toEqual('foo');
-        expect(actual.data[1].boolKey).toBe(false);
+        expect(actual[1].strKey).toEqual('foo');
+        expect(actual[1].boolKey).toBe(false);
     })
 
     it('can add indexKeys via contructor options', () => {
@@ -78,7 +78,7 @@ describe('DynamicDataStore', () => {
         const updated = dt.select({strKey: 'foo', numKey: 2}).first();
         expect(updated.boolKey).toBe(false);
         const unchanged = dt.select({boolKey: true});
-        expect(unchanged.data.length).toBe(3);
+        expect(unchanged.length).toBe(3);
     })
 
     it('can update multiple records using the update function', () => {
@@ -97,8 +97,8 @@ describe('DynamicDataStore', () => {
         const unchanged = dt.select({strKey: 'foo', numKey: 4}).first();
         expect(unchanged.boolKey).toBe(false);
         const updated = dt.select({numKey: between(2, 3)});
-        expect(updated.data.length).toBe(2);
-        expect(updated.data.every(c => c.boolKey === true)).toBe(true);
+        expect(updated.length).toBe(2);
+        expect(updated.every(c => c.boolKey === true)).toBe(true);
     })
 
     it('can remove records by query data', () => {
@@ -174,8 +174,8 @@ describe('DynamicDataStore', () => {
         });
 
         const results = dt.select({strKey: 'foo', objKey: {strKey: 'bar'}});
-        expect(results.data.length).toBe(2);
+        expect(results.length).toBe(2);
         const valRes = dt.select({strKey: 'bar', objKey: {strKey: startingWith('ba')}});
-        expect(valRes.data.length).toBe(4);
+        expect(valRes.length).toBe(4);
     })
 })

--- a/test/value-matcher.spec.ts
+++ b/test/value-matcher.spec.ts
@@ -1,4 +1,4 @@
-import { between, containing, endingWith, greaterThan, lessThan, matching, startingWith } from "../src/value-matcher";
+import { between, containing, endingWith, greaterThan, havingValue, lessThan, matching, not, startingWith } from "../src/value-matcher";
 
 describe('ValueMatcher', () => {
     describe('Between', () => {
@@ -176,6 +176,36 @@ describe('ValueMatcher', () => {
         testData.forEach(d => {
             it(`returns the correct result for: ${JSON.stringify(d)}`, () => {
                 expect(endingWith(d.end).isMatch(d.actual)).withContext(d.ctx).toBe(d.expected);
+            })
+        })
+    })
+
+    describe('HavingValue', () => {
+        const testData = [
+            {actual: null, expected: false, ctx: 'null actual results in false'},
+            {actual: undefined, expected: false, ctx: 'undefined actual results in false'},
+            {actual: false, expected: true, ctx: 'false actual results in true'},
+            {actual: 0, expected: true, ctx: '0 actual results in true'},
+            {actual: '', expected: true, ctx: 'empty string actual results in true'},
+            {actual: {}, expected: true, ctx: 'empty object actual results in true'},
+            {actual: () => null, expected: true, ctx: 'function actual returning null results in true'}
+        ];
+        testData.forEach(d => {
+            it(`returns the correct result for: ${JSON.stringify(d)}`, () => {
+                expect(havingValue().isMatch(d.actual)).withContext(d.ctx).toBe(d.expected);
+            })
+        })
+    })
+
+    describe('Not', () => {
+        const testData = [
+            {matcher: between(3, 5), actual: 7, expected: true, ctx: 'between 3 and 5 with 7 actual results in true'},
+            {matcher: containing(42), actual: [12, 24], expected: true, ctx: 'containing 42 with [12, 24] actual results in true'},
+            {matcher: havingValue(), actual: null, expected: true, ctx: 'havingValue with null actual results in true'}
+        ];
+        testData.forEach(d => {
+            it(`returns the correct result for: ${JSON.stringify(d)}`, () => {
+                expect(not(d.matcher).isMatch(d.actual)).withContext(d.ctx).toBe(d.expected);
             })
         })
     })


### PR DESCRIPTION
* select now returns an array object that can be ordered by specified fields in either ascending or descending order and which has a first and last getter
* added a `havingValue` and `not` `ValueMatcher` that can be used to better refine the results
* returned array object can also be further queried allowing for multi-part filtering of results